### PR TITLE
Fixed BulkInsert throwing an exception with custom column name on SQLite

### DIFF
--- a/EFCore.BulkExtensions.Tests/BulkInsertOrUpdate/BulkInsertTests.cs
+++ b/EFCore.BulkExtensions.Tests/BulkInsertOrUpdate/BulkInsertTests.cs
@@ -164,4 +164,39 @@ public class BulkInsertTests : IClassFixture<BulkInsertTests.DatabaseFixture>, I
             Assert.True(itemsFromDb.OrderBy(x => x.GuidProperty).Select(x => x.GuidProperty).SequenceEqual(items.OrderBy(x => x.GuidProperty).Select(x => x.GuidProperty)));
         }
     }
+
+    [Theory]
+    [InlineData(DbServerType.SQLServer)]
+    [InlineData(DbServerType.SQLite)]
+    public void BulkInsert_CustomColumnNames(DbServerType dbType)
+    {
+        var item = new Entity_CustomColumnNames()
+        {
+            Id = 0,
+            CustomColumn = "Value1",
+            GuidProperty = Guid.NewGuid(),
+        };
+
+        var item2 = new Entity_CustomColumnNames()
+        {
+            Id = 0,
+            CustomColumn = "Value2",
+            GuidProperty = Guid.NewGuid(),
+        };
+
+        using (var db = _dbFixture.GetDb(dbType))
+        {
+            var items = new[] { item, item2 };
+            db.BulkInsert(items, c =>
+            {
+                c.SetOutputIdentity = true;
+            });
+        }
+
+        using (var db = _dbFixture.GetDb(dbType))
+        {
+            var insertedItem = db.EntityCustomColumnNames.Single(x => x.GuidProperty == item.GuidProperty);
+            Assert.Equal("Value1", insertedItem.CustomColumn);
+        }
+    }
 }

--- a/EFCore.BulkExtensions/SqlAdapters/SQLite/SqLiteAdapter.cs
+++ b/EFCore.BulkExtensions/SqlAdapters/SQLite/SqLiteAdapter.cs
@@ -403,7 +403,7 @@ public class SqliteOperationsAdapter : ISqlOperationsAdapter
 
             if (propertyEntityType != null)
             {
-                string? columnName = propertyEntityType.GetColumnName(tableInfo.ObjectIdentifier);
+                string columnName = propertyEntityType.Name;
                 var propertyType = Nullable.GetUnderlyingType(property.PropertyType) ?? property.PropertyType;
 
                 //SqliteType(CpropertyType.Name): Text(String, Decimal, DateTime); Integer(Int16, Int32, Int64) Real(Float, Double) Blob(Guid)


### PR DESCRIPTION
This PR fixes #124, which is that an exception was thrown when using a custom column name in SQLite.

The reason for this exception is that the custom column name was used as the parameter name for insertions when generating the command. However, when setting the parameters, it tried to set the parameter with the property name instead. This PR fixes this error by using the property name in both places.