### PR TITLE
fix: do not use identity column when identity insert is off #131

### DIFF
--- a/EFCore.BulkExtensions/SqlAdapters/SQLite/SqlQueryBuilderSqlite.cs
+++ b/EFCore.BulkExtensions/SqlAdapters/SQLite/SqlQueryBuilderSqlite.cs
@@ -43,7 +43,7 @@ public class SqlQueryBuilderSqlite : SqlAdapters.QueryBuilderExtensions
         List<string> propertiesList = tableInfo.PropertyColumnNamesDict.Keys.ToList();
 
         bool keepIdentity = tableInfo.BulkConfig.SqlBulkCopyOptions.HasFlag(SqlBulkCopyOptions.KeepIdentity);
-        if (operationType == OperationType.Insert && !keepIdentity && tableInfo.HasIdentity)
+        if (!tableInfo.InsertToTempTable && !keepIdentity && tableInfo.HasIdentity)
         {
             var identityPropertyName = tableInfo.PropertyColumnNamesDict.SingleOrDefault(a => a.Value == tableInfo.IdentityColumnName).Key;
             columnsList = columnsList.Where(a => a != tableInfo.IdentityColumnName).ToList();


### PR DESCRIPTION
There is a problem with SQLite when using `BulkInsertOrUpdateAsync` due to the generated SQL containing identity column. This PR should fix this issue.