### PR TITLE
Fix: Identity insert handling for merge (InsertOrUpdate) statements in SQLite

### DIFF
--- a/EFCore.BulkExtensions.Tests/BulkInsertOrUpdate/SimpleBulkTestsContext.cs
+++ b/EFCore.BulkExtensions.Tests/BulkInsertOrUpdate/SimpleBulkTestsContext.cs
@@ -11,8 +11,9 @@ public class SimpleBulkTestsContext : DbContext
 {
     public DbSet<SimpleItem> SimpleItems { get; set; } = null!;
 
-
     public DbSet<Entity_CustomColumnNames> EntityCustomColumnNames { get; set; } = null!;
+    
+    public DbSet<UniqueItem> UniqueItems { get; set; } = null!;
 
     public SimpleBulkTestsContext(DbContextOptions options)
         : base(options)
@@ -21,6 +22,9 @@ public class SimpleBulkTestsContext : DbContext
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
+        modelBuilder.Entity<UniqueItem>()
+            .HasIndex(x => new { x.FirstName, x.LastName })
+            .IsUnique();
     }
 
     public List<SimpleItem> GetItemsOfBulk(Guid bulkId)
@@ -41,6 +45,17 @@ public class SimpleItem
 
     [MaxLength(500)]
     public string? StringProperty { get; set; }
+}
+
+public class UniqueItem
+{
+    [Key]
+    [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+    public int Id { get; set; }
+
+    public string FirstName { get; set; } = "";
+
+    public string LastName { get; set; } = "";
 }
 
 public class Entity_CustomColumnNames

--- a/EFCore.BulkExtensions.Tests/EFCoreBulkTest.cs
+++ b/EFCore.BulkExtensions.Tests/EFCoreBulkTest.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Text.Json;
+using Microsoft.Data.SqlClient;
 using Xunit;
 
 namespace EFCore.BulkExtensions.Tests;
@@ -533,7 +534,7 @@ public class EFCoreBulkTest : IAssemblyFixture<DbAssemblyFixture>
         }
         if (isBulk)
         {
-            var bulkConfig = new BulkConfig() { SetOutputIdentity = true, CalculateStats = true };
+            var bulkConfig = new BulkConfig { SetOutputIdentity = true, CalculateStats = true, SqlBulkCopyOptions = SqlBulkCopyOptions.KeepIdentity};
             context.BulkInsertOrUpdate(entities, bulkConfig, (a) => WriteProgress(a));
             if (dbServer == DbServerType.SQLServer)
             {

--- a/EFCore.BulkExtensions.Tests/EFCoreBulkTestAsync.cs
+++ b/EFCore.BulkExtensions.Tests/EFCoreBulkTestAsync.cs
@@ -222,7 +222,7 @@ public class EFCoreBulkTestAsync : IAssemblyFixture<DbAssemblyFixture>
         }
         if (isBulk)
         {
-            var bulkConfig = new BulkConfig() { SetOutputIdentity = true, CalculateStats = true, SqlBulkCopyOptions = SqlBulkCopyOptions.FireTriggers | SqlBulkCopyOptions.KeepIdentity};
+            var bulkConfig = new BulkConfig() { SetOutputIdentity = true, CalculateStats = true, SqlBulkCopyOptions = SqlBulkCopyOptions.KeepIdentity};
             await context.BulkInsertOrUpdateAsync(entities, bulkConfig);
             if (dbServer == DbServerType.SQLServer)
             {

--- a/EFCore.BulkExtensions.Tests/EFCoreBulkTestAsync.cs
+++ b/EFCore.BulkExtensions.Tests/EFCoreBulkTestAsync.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
 using Xunit;
 
 namespace EFCore.BulkExtensions.Tests;
@@ -221,7 +222,7 @@ public class EFCoreBulkTestAsync : IAssemblyFixture<DbAssemblyFixture>
         }
         if (isBulk)
         {
-            var bulkConfig = new BulkConfig() { SetOutputIdentity = true, CalculateStats = true };
+            var bulkConfig = new BulkConfig() { SetOutputIdentity = true, CalculateStats = true, SqlBulkCopyOptions = SqlBulkCopyOptions.FireTriggers | SqlBulkCopyOptions.KeepIdentity};
             await context.BulkInsertOrUpdateAsync(entities, bulkConfig);
             if (dbServer == DbServerType.SQLServer)
             {

--- a/EFCore.BulkExtensions/SqlAdapters/SQLite/SqlQueryBuilderSqlite.cs
+++ b/EFCore.BulkExtensions/SqlAdapters/SQLite/SqlQueryBuilderSqlite.cs
@@ -43,7 +43,7 @@ public class SqlQueryBuilderSqlite : SqlAdapters.QueryBuilderExtensions
         List<string> propertiesList = tableInfo.PropertyColumnNamesDict.Keys.ToList();
 
         bool keepIdentity = tableInfo.BulkConfig.SqlBulkCopyOptions.HasFlag(SqlBulkCopyOptions.KeepIdentity);
-        if (operationType == OperationType.Insert && !keepIdentity && tableInfo.HasIdentity)
+        if (!tableInfo.InsertToTempTable && !keepIdentity && tableInfo.HasIdentity)
         {
             var identityPropertyName = tableInfo.PropertyColumnNamesDict.SingleOrDefault(a => a.Value == tableInfo.IdentityColumnName).Key;
             columnsList = columnsList.Where(a => a != tableInfo.IdentityColumnName).ToList();


### PR DESCRIPTION
I checked the integration test and found out that they attempt to do identity inserts but they don't specify identity insert flag. The fix should be complete.