### PR TITLE
Bump vulnerable dependency - npgsql to 8.0.3

### DIFF
--- a/NugetProjects/EFCore.BulkExtensions.v8.PostgreSql/EFCore.BulkExtensions.v8.PostgreSql.csproj
+++ b/NugetProjects/EFCore.BulkExtensions.v8.PostgreSql/EFCore.BulkExtensions.v8.PostgreSql.csproj
@@ -2,8 +2,8 @@
     
     <ItemGroup>
         <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.5"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0"/>
-        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.6"/>
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4"/>
     </ItemGroup>
 
 </Project>

--- a/NugetProjects/EFCore.BulkExtensions.v8/EFCore.BulkExtensions.v8.csproj
+++ b/NugetProjects/EFCore.BulkExtensions.v8/EFCore.BulkExtensions.v8.csproj
@@ -6,7 +6,7 @@
         <PackageReference Include="NetTopologySuite.IO.SqlServerBytes" Version="2.1.0" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.HierarchyId" Version="8.0.0" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.NetTopologySuite" Version="8.0.0" />
-        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4" />
         <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.0" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="8.0.0" />
         <PackageReference Include="NetTopologySuite.IO.SpatiaLite" Version="2.0.0" />


### PR DESCRIPTION
Veracode security scanner is raising this as an issue.
Bump NpgSQL to version without reported vulnerbilities