### PR TITLE
Change BulkOperation input type from IList to ICollection

### DIFF
--- a/EFCore.BulkExtensions/DbContextBulkExtensions.cs
+++ b/EFCore.BulkExtensions/DbContextBulkExtensions.cs
@@ -16,7 +16,7 @@ public static class DbContextBulkExtensions
     /// <summary>
     /// Extension method to bulk insert data
     /// </summary>
-    public static void BulkInsert<T>(this DbContext context, IList<T> entities, BulkConfig? bulkConfig = null, Action<decimal>? progress = null, Type? type = null) where T : class
+    public static void BulkInsert<T>(this DbContext context, ICollection<T> entities, BulkConfig? bulkConfig = null, Action<decimal>? progress = null, Type? type = null) where T : class
     {
         DbContextBulkTransaction.Execute(context, type, entities, OperationType.Insert, bulkConfig, progress);
     }
@@ -24,7 +24,7 @@ public static class DbContextBulkExtensions
     /// <summary>
     /// Extension method to bulk insert data
     /// </summary>
-    public static Task BulkInsertAsync<T>(this DbContext context, IList<T> entities, BulkConfig? bulkConfig = null, Action<decimal>? progress = null, Type? type = null, CancellationToken cancellationToken = default) where T : class
+    public static Task BulkInsertAsync<T>(this DbContext context, ICollection<T> entities, BulkConfig? bulkConfig = null, Action<decimal>? progress = null, Type? type = null, CancellationToken cancellationToken = default) where T : class
     {
         return DbContextBulkTransaction.ExecuteAsync(context, type, entities, OperationType.Insert, bulkConfig, progress, cancellationToken);
     }
@@ -32,7 +32,7 @@ public static class DbContextBulkExtensions
     /// <summary>
     /// Extension method to bulk insert data
     /// </summary>
-    public static void BulkInsert<T>(this DbContext context, IList<T> entities, Action<BulkConfig>? bulkAction, Action<decimal>? progress = null, Type? type = null) where T : class
+    public static void BulkInsert<T>(this DbContext context, ICollection<T> entities, Action<BulkConfig>? bulkAction, Action<decimal>? progress = null, Type? type = null) where T : class
     {
         BulkConfig bulkConfig = new();
         bulkAction?.Invoke(bulkConfig);
@@ -42,7 +42,7 @@ public static class DbContextBulkExtensions
     /// <summary>
     /// Extension method to bulk insert data
     /// </summary>
-    public static Task BulkInsertAsync<T>(this DbContext context, IList<T> entities, Action<BulkConfig>? bulkAction, Action<decimal>? progress = null, Type? type = null, CancellationToken cancellationToken = default) where T : class
+    public static Task BulkInsertAsync<T>(this DbContext context, ICollection<T> entities, Action<BulkConfig>? bulkAction, Action<decimal>? progress = null, Type? type = null, CancellationToken cancellationToken = default) where T : class
     {
         BulkConfig bulkConfig = new();
         bulkAction?.Invoke(bulkConfig);
@@ -55,7 +55,7 @@ public static class DbContextBulkExtensions
     /// Extension method to bulk insert or update data
     /// </summary>
     #region BulkInsertOrUpdate
-    public static void BulkInsertOrUpdate<T>(this DbContext context, IList<T> entities, BulkConfig? bulkConfig = null, Action<decimal>? progress = null, Type? type = null) where T : class
+    public static void BulkInsertOrUpdate<T>(this DbContext context, ICollection<T> entities, BulkConfig? bulkConfig = null, Action<decimal>? progress = null, Type? type = null) where T : class
     {
         DbContextBulkTransaction.Execute(context, type, entities, OperationType.InsertOrUpdate, bulkConfig, progress);
     }
@@ -71,7 +71,7 @@ public static class DbContextBulkExtensions
     /// <param name="type"></param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    public static Task BulkInsertOrUpdateAsync<T>(this DbContext context, IList<T> entities, BulkConfig? bulkConfig = null, Action<decimal>? progress = null, Type? type = null, CancellationToken cancellationToken = default) where T : class
+    public static Task BulkInsertOrUpdateAsync<T>(this DbContext context, ICollection<T> entities, BulkConfig? bulkConfig = null, Action<decimal>? progress = null, Type? type = null, CancellationToken cancellationToken = default) where T : class
     {
         return DbContextBulkTransaction.ExecuteAsync(context, type, entities, OperationType.InsertOrUpdate, bulkConfig, progress, cancellationToken);
     }
@@ -85,7 +85,7 @@ public static class DbContextBulkExtensions
     /// <param name="bulkAction"></param>
     /// <param name="progress"></param>
     /// <param name="type"></param>
-    public static void BulkInsertOrUpdate<T>(this DbContext context, IList<T> entities, Action<BulkConfig> bulkAction, Action<decimal>? progress = null, Type? type = null) where T : class
+    public static void BulkInsertOrUpdate<T>(this DbContext context, ICollection<T> entities, Action<BulkConfig> bulkAction, Action<decimal>? progress = null, Type? type = null) where T : class
     {
         BulkConfig bulkConfig = new();
         bulkAction?.Invoke(bulkConfig);
@@ -103,7 +103,7 @@ public static class DbContextBulkExtensions
     /// <param name="type"></param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    public static Task BulkInsertOrUpdateAsync<T>(this DbContext context, IList<T> entities, Action<BulkConfig> bulkAction, Action<decimal>? progress = null, Type? type = null, CancellationToken cancellationToken = default) where T : class
+    public static Task BulkInsertOrUpdateAsync<T>(this DbContext context, ICollection<T> entities, Action<BulkConfig> bulkAction, Action<decimal>? progress = null, Type? type = null, CancellationToken cancellationToken = default) where T : class
     {
         BulkConfig bulkConfig = new();
         bulkAction?.Invoke(bulkConfig);
@@ -117,7 +117,7 @@ public static class DbContextBulkExtensions
     /// <summary>
     /// Extension method to bulk insert, update and delete data
     /// </summary>
-    public static void BulkInsertOrUpdateOrDelete<T>(this DbContext context, IList<T> entities, BulkConfig? bulkConfig = null, Action<decimal>? progress = null, Type? type = null) where T : class
+    public static void BulkInsertOrUpdateOrDelete<T>(this DbContext context, ICollection<T> entities, BulkConfig? bulkConfig = null, Action<decimal>? progress = null, Type? type = null) where T : class
     {
         DbContextBulkTransaction.Execute(context, type, entities, OperationType.InsertOrUpdateOrDelete, bulkConfig, progress);
     }
@@ -125,7 +125,7 @@ public static class DbContextBulkExtensions
     /// <summary>
     /// Extension method to bulk insert, update and delete data
     /// </summary>
-    public static Task BulkInsertOrUpdateOrDeleteAsync<T>(this DbContext context, IList<T> entities, BulkConfig? bulkConfig = null, Action<decimal>? progress = null, Type? type = null, CancellationToken cancellationToken = default) where T : class
+    public static Task BulkInsertOrUpdateOrDeleteAsync<T>(this DbContext context, ICollection<T> entities, BulkConfig? bulkConfig = null, Action<decimal>? progress = null, Type? type = null, CancellationToken cancellationToken = default) where T : class
     {
         return DbContextBulkTransaction.ExecuteAsync(context, type, entities, OperationType.InsertOrUpdateOrDelete, bulkConfig, progress, cancellationToken);
     }
@@ -133,7 +133,7 @@ public static class DbContextBulkExtensions
     /// <summary>
     /// Extension method to bulk insert, update and delete data
     /// </summary>
-    public static void BulkInsertOrUpdateOrDelete<T>(this DbContext context, IList<T> entities, Action<BulkConfig>? bulkAction, Action<decimal>? progress = null, Type? type = null) where T : class
+    public static void BulkInsertOrUpdateOrDelete<T>(this DbContext context, ICollection<T> entities, Action<BulkConfig>? bulkAction, Action<decimal>? progress = null, Type? type = null) where T : class
     {
         BulkConfig bulkConfig = new();
         bulkAction?.Invoke(bulkConfig);
@@ -143,7 +143,7 @@ public static class DbContextBulkExtensions
     /// <summary>
     /// Extension method to bulk insert, update and delete data
     /// </summary>
-    public static Task BulkInsertOrUpdateOrDeleteAsync<T>(this DbContext context, IList<T> entities, Action<BulkConfig>? bulkAction, Action<decimal>? progress = null, Type? type = null, CancellationToken cancellationToken = default) where T : class
+    public static Task BulkInsertOrUpdateOrDeleteAsync<T>(this DbContext context, ICollection<T> entities, Action<BulkConfig>? bulkAction, Action<decimal>? progress = null, Type? type = null, CancellationToken cancellationToken = default) where T : class
     {
         BulkConfig bulkConfig = new();
         bulkAction?.Invoke(bulkConfig);
@@ -157,7 +157,7 @@ public static class DbContextBulkExtensions
     /// <summary>
     /// Extension method to bulk update data
     /// </summary>
-    public static void BulkUpdate<T>(this DbContext context, IList<T> entities, BulkConfig? bulkConfig = null, Action<decimal>? progress = null, Type? type = null) where T : class
+    public static void BulkUpdate<T>(this DbContext context, ICollection<T> entities, BulkConfig? bulkConfig = null, Action<decimal>? progress = null, Type? type = null) where T : class
     {
         DbContextBulkTransaction.Execute(context, type, entities, OperationType.Update, bulkConfig, progress);
     }
@@ -165,7 +165,7 @@ public static class DbContextBulkExtensions
     /// <summary>
     /// Extension method to bulk update data
     /// </summary>
-    public static Task BulkUpdateAsync<T>(this DbContext context, IList<T> entities, BulkConfig? bulkConfig = null, Action<decimal>? progress = null, Type? type = null, CancellationToken cancellationToken = default) where T : class
+    public static Task BulkUpdateAsync<T>(this DbContext context, ICollection<T> entities, BulkConfig? bulkConfig = null, Action<decimal>? progress = null, Type? type = null, CancellationToken cancellationToken = default) where T : class
     {
         return DbContextBulkTransaction.ExecuteAsync(context, type, entities, OperationType.Update, bulkConfig, progress, cancellationToken);
     }
@@ -173,7 +173,7 @@ public static class DbContextBulkExtensions
     /// <summary>
     /// Extension method to bulk update data
     /// </summary>
-    public static void BulkUpdate<T>(this DbContext context, IList<T> entities, Action<BulkConfig>? bulkAction, Action<decimal>? progress = null, Type? type = null) where T : class
+    public static void BulkUpdate<T>(this DbContext context, ICollection<T> entities, Action<BulkConfig>? bulkAction, Action<decimal>? progress = null, Type? type = null) where T : class
     {
         BulkConfig bulkConfig = new();
         bulkAction?.Invoke(bulkConfig);
@@ -183,7 +183,7 @@ public static class DbContextBulkExtensions
     /// <summary>
     /// Extension method to bulk update data
     /// </summary>
-    public static Task BulkUpdateAsync<T>(this DbContext context, IList<T> entities, Action<BulkConfig>? bulkAction, Action<decimal>? progress = null, Type? type = null, CancellationToken cancellationToken = default) where T : class
+    public static Task BulkUpdateAsync<T>(this DbContext context, ICollection<T> entities, Action<BulkConfig>? bulkAction, Action<decimal>? progress = null, Type? type = null, CancellationToken cancellationToken = default) where T : class
     {
         BulkConfig bulkConfig = new();
         bulkAction?.Invoke(bulkConfig);
@@ -196,7 +196,7 @@ public static class DbContextBulkExtensions
     /// <summary>
     /// Extension method to bulk delete data
     /// </summary>
-    public static void BulkDelete<T>(this DbContext context, IList<T> entities, BulkConfig? bulkConfig = null, Action<decimal>? progress = null, Type? type = null) where T : class
+    public static void BulkDelete<T>(this DbContext context, ICollection<T> entities, BulkConfig? bulkConfig = null, Action<decimal>? progress = null, Type? type = null) where T : class
     {
         DbContextBulkTransaction.Execute(context, type, entities, OperationType.Delete, bulkConfig, progress);
     }
@@ -204,7 +204,7 @@ public static class DbContextBulkExtensions
     /// <summary>
     /// Extension method to bulk delete data
     /// </summary>
-    public static Task BulkDeleteAsync<T>(this DbContext context, IList<T> entities, BulkConfig? bulkConfig = null, Action<decimal>? progress = null, Type? type = null, CancellationToken cancellationToken = default) where T : class
+    public static Task BulkDeleteAsync<T>(this DbContext context, ICollection<T> entities, BulkConfig? bulkConfig = null, Action<decimal>? progress = null, Type? type = null, CancellationToken cancellationToken = default) where T : class
     {
         return DbContextBulkTransaction.ExecuteAsync(context, type, entities, OperationType.Delete, bulkConfig, progress, cancellationToken);
     }
@@ -212,7 +212,7 @@ public static class DbContextBulkExtensions
     /// <summary>
     /// Extension method to bulk delete data
     /// </summary>
-    public static void BulkDelete<T>(this DbContext context, IList<T> entities, Action<BulkConfig>? bulkAction, Action<decimal>? progress = null, Type? type = null) where T : class
+    public static void BulkDelete<T>(this DbContext context, ICollection<T> entities, Action<BulkConfig>? bulkAction, Action<decimal>? progress = null, Type? type = null) where T : class
     {
         BulkConfig bulkConfig = new();
         bulkAction?.Invoke(bulkConfig);
@@ -222,7 +222,7 @@ public static class DbContextBulkExtensions
     /// <summary>
     /// Extension method to bulk delete data
     /// </summary>
-    public static Task BulkDeleteAsync<T>(this DbContext context, IList<T> entities, Action<BulkConfig>? bulkAction, Action<decimal>? progress = null, Type? type = null, CancellationToken cancellationToken = default) where T : class
+    public static Task BulkDeleteAsync<T>(this DbContext context, ICollection<T> entities, Action<BulkConfig>? bulkAction, Action<decimal>? progress = null, Type? type = null, CancellationToken cancellationToken = default) where T : class
     {
         BulkConfig bulkConfig = new();
         bulkAction?.Invoke(bulkConfig);
@@ -236,7 +236,7 @@ public static class DbContextBulkExtensions
     /// <summary>
     /// Extension method to bulk read data
     /// </summary>
-    public static void BulkRead<T>(this DbContext context, IList<T> entities, BulkConfig? bulkConfig = null, Action<decimal>? progress = null, Type? type = null) where T : class
+    public static void BulkRead<T>(this DbContext context, ICollection<T> entities, BulkConfig? bulkConfig = null, Action<decimal>? progress = null, Type? type = null) where T : class
     {
         DbContextBulkTransaction.Execute(context, type, entities, OperationType.Read, bulkConfig, progress);
     }
@@ -244,7 +244,7 @@ public static class DbContextBulkExtensions
     /// <summary>
     /// Extension method to bulk read data
     /// </summary>
-    public static Task BulkReadAsync<T>(this DbContext context, IList<T> entities, BulkConfig? bulkConfig = null, Action<decimal>? progress = null, Type? type = null, CancellationToken cancellationToken = default) where T : class
+    public static Task BulkReadAsync<T>(this DbContext context, ICollection<T> entities, BulkConfig? bulkConfig = null, Action<decimal>? progress = null, Type? type = null, CancellationToken cancellationToken = default) where T : class
     {
         return DbContextBulkTransaction.ExecuteAsync(context, type, entities, OperationType.Read, bulkConfig, progress, cancellationToken);
     }
@@ -252,7 +252,7 @@ public static class DbContextBulkExtensions
     /// <summary>
     /// Extension method to bulk read data
     /// </summary>
-    public static void BulkRead<T>(this DbContext context, IList<T> entities, Action<BulkConfig>? bulkAction, Action<decimal>? progress = null, Type? type = null) where T : class
+    public static void BulkRead<T>(this DbContext context, ICollection<T> entities, Action<BulkConfig>? bulkAction, Action<decimal>? progress = null, Type? type = null) where T : class
     {
         BulkConfig bulkConfig = new();
         bulkAction?.Invoke(bulkConfig);
@@ -262,7 +262,7 @@ public static class DbContextBulkExtensions
     /// <summary>
     /// Extension method to bulk read data
     /// </summary>
-    public static Task BulkReadAsync<T>(this DbContext context, IList<T> entities, Action<BulkConfig>? bulkAction, Action<decimal>? progress = null, Type? type = null, CancellationToken cancellationToken = default) where T : class
+    public static Task BulkReadAsync<T>(this DbContext context, ICollection<T> entities, Action<BulkConfig>? bulkAction, Action<decimal>? progress = null, Type? type = null, CancellationToken cancellationToken = default) where T : class
     {
         BulkConfig bulkConfig = new();
         bulkAction?.Invoke(bulkConfig);

--- a/EFCore.BulkExtensions/DbContextBulkTransaction.cs
+++ b/EFCore.BulkExtensions/DbContextBulkTransaction.cs
@@ -1,7 +1,7 @@
-﻿using EFCore.BulkExtensions.SqlAdapters;
-using Microsoft.EntityFrameworkCore;
+﻿using Microsoft.EntityFrameworkCore;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -9,11 +9,14 @@ namespace EFCore.BulkExtensions;
 
 internal static class DbContextBulkTransaction
 {
-    public static void Execute<T>(DbContext context, Type? type, IList<T> entities, OperationType operationType, BulkConfig? bulkConfig, Action<decimal>? progress) where T : class
+    public static void Execute<T>(DbContext context, Type? type, ICollection<T> entities, OperationType operationType, BulkConfig? bulkConfig, Action<decimal>? progress) where T : class
     {
         type ??= typeof(T);
 
         CheckForMySQLUnsupportedFeatures(context, operationType, bulkConfig);
+
+        // Ensure we have an IList<T> for downstream operations that rely on indexing
+        IList<T> entitiesList = entities as IList<T> ?? entities.ToList();
 
         using (ActivitySources.StartExecuteActivity(operationType, entities.Count))
         {
@@ -38,15 +41,15 @@ internal static class DbContextBulkTransaction
             }
             else
             {
-                TableInfo tableInfo = TableInfo.CreateInstance(context, type, entities, operationType, bulkConfig);
+                TableInfo tableInfo = TableInfo.CreateInstance(context, type, entitiesList, operationType, bulkConfig);
 
                 if (operationType == OperationType.Insert && !tableInfo.BulkConfig.SetOutputIdentity && tableInfo.BulkConfig.CustomSourceTableName == null)
                 {
-                    SqlBulkOperation.Insert(context, type, entities, tableInfo, progress);
+                    SqlBulkOperation.Insert(context, type, entitiesList, tableInfo, progress);
                 }
                 else if (operationType == OperationType.Read)
                 {
-                    SqlBulkOperation.Read(context, type, entities, tableInfo, progress);
+                    SqlBulkOperation.Read(context, type, entitiesList, tableInfo, progress);
                 }
                 else if (operationType == OperationType.Truncate)
                 {
@@ -54,7 +57,7 @@ internal static class DbContextBulkTransaction
                 }
                 else
                 {
-                    SqlBulkOperation.Merge(context, type, entities, tableInfo, operationType, progress);
+                    SqlBulkOperation.Merge(context, type, entitiesList, tableInfo, operationType, progress);
                 }
             }
         }
@@ -81,9 +84,12 @@ internal static class DbContextBulkTransaction
         // }
     }
 
-    public static async Task ExecuteAsync<T>(DbContext context, Type? type, IList<T> entities, OperationType operationType, BulkConfig? bulkConfig, Action<decimal>? progress, CancellationToken cancellationToken = default) where T : class
+    public static async Task ExecuteAsync<T>(DbContext context, Type? type, ICollection<T> entities, OperationType operationType, BulkConfig? bulkConfig, Action<decimal>? progress, CancellationToken cancellationToken = default) where T : class
     {
         type ??= typeof(T);
+
+        // Ensure we have an IList<T> for downstream operations that rely on indexing
+        IList<T> entitiesList = entities as IList<T> ?? entities.ToList();
 
         using (ActivitySources.StartExecuteActivity(operationType, entities.Count))
         {
@@ -102,15 +108,15 @@ internal static class DbContextBulkTransaction
             }
             else
             {
-                TableInfo tableInfo = TableInfo.CreateInstance(context, type, entities, operationType, bulkConfig);
+                TableInfo tableInfo = TableInfo.CreateInstance(context, type, entitiesList, operationType, bulkConfig);
 
                 if (operationType == OperationType.Insert && !tableInfo.BulkConfig.SetOutputIdentity)
                 {
-                    await SqlBulkOperation.InsertAsync(context, type, entities, tableInfo, progress, cancellationToken).ConfigureAwait(false);
+                    await SqlBulkOperation.InsertAsync(context, type, entitiesList, tableInfo, progress, cancellationToken).ConfigureAwait(false);
                 }
                 else if (operationType == OperationType.Read)
                 {
-                    await SqlBulkOperation.ReadAsync(context, type, entities, tableInfo, progress, cancellationToken).ConfigureAwait(false);
+                    await SqlBulkOperation.ReadAsync(context, type, entitiesList, tableInfo, progress, cancellationToken).ConfigureAwait(false);
                 }
                 else if (operationType == OperationType.Truncate)
                 {
@@ -118,7 +124,7 @@ internal static class DbContextBulkTransaction
                 }
                 else
                 {
-                    await SqlBulkOperation.MergeAsync(context, type, entities, tableInfo, operationType, progress, cancellationToken).ConfigureAwait(false);
+                    await SqlBulkOperation.MergeAsync(context, type, entitiesList, tableInfo, operationType, progress, cancellationToken).ConfigureAwait(false);
                 }
             }
         }

--- a/EFCore.BulkExtensions/SqlAdapters/ISqlOperationsAdapter.cs
+++ b/EFCore.BulkExtensions/SqlAdapters/ISqlOperationsAdapter.cs
@@ -15,32 +15,32 @@ public interface ISqlOperationsAdapter
     /// <summary>
     /// Inserts a list of entities
     /// </summary>
-    void Insert<T>(DbContext context, Type type, IList<T> entities, TableInfo tableInfo, Action<decimal>? progress);
+    void Insert<T>(DbContext context, Type type, ICollection<T> entities, TableInfo tableInfo, Action<decimal>? progress);
 
     /// <summary>
     /// Inserts a list of entities
     /// </summary>
-    Task InsertAsync<T>(DbContext context, Type type, IList<T> entities, TableInfo tableInfo, Action<decimal>? progress, CancellationToken cancellationToken);
+    Task InsertAsync<T>(DbContext context, Type type, ICollection<T> entities, TableInfo tableInfo, Action<decimal>? progress, CancellationToken cancellationToken);
 
     /// <summary>
     /// Merges a list of entities with a table source
     /// </summary>
-    void Merge<T>(DbContext context, Type type, IList<T> entities, TableInfo tableInfo, OperationType operationType, Action<decimal>? progress) where T : class;
+    void Merge<T>(DbContext context, Type type, ICollection<T> entities, TableInfo tableInfo, OperationType operationType, Action<decimal>? progress) where T : class;
 
     /// <summary>
     /// Merges a list of entities with a table source
     /// </summary>
-    Task MergeAsync<T>(DbContext context, Type type, IList<T> entities, TableInfo tableInfo, OperationType operationType, Action<decimal>? progress, CancellationToken cancellationToken) where T : class;
+    Task MergeAsync<T>(DbContext context, Type type, ICollection<T> entities, TableInfo tableInfo, OperationType operationType, Action<decimal>? progress, CancellationToken cancellationToken) where T : class;
 
     /// <summary>
     /// Reads a list of entities from database
     /// </summary>
-    void Read<T>(DbContext context, Type type, IList<T> entities, TableInfo tableInfo, Action<decimal>? progress) where T : class;
+    void Read<T>(DbContext context, Type type, ICollection<T> entities, TableInfo tableInfo, Action<decimal>? progress) where T : class;
 
     /// <summary>
     /// Reads a list of entities from database
     /// </summary>
-    Task ReadAsync<T>(DbContext context, Type type, IList<T> entities, TableInfo tableInfo, Action<decimal>? progress, CancellationToken cancellationToken) where T : class;
+    Task ReadAsync<T>(DbContext context, Type type, ICollection<T> entities, TableInfo tableInfo, Action<decimal>? progress, CancellationToken cancellationToken) where T : class;
 
     /// <summary>
     /// Truncates a table

--- a/EFCore.BulkExtensions/SqlAdapters/MySql/MySqlAdapter.cs
+++ b/EFCore.BulkExtensions/SqlAdapters/MySql/MySqlAdapter.cs
@@ -20,20 +20,20 @@ public class MySqlAdapter : ISqlOperationsAdapter
     /// <inheritdoc/>
     #region Methods
     // Insert
-    public void Insert<T>(DbContext context, Type type, IList<T> entities, TableInfo tableInfo, Action<decimal>? progress)
+    public void Insert<T>(DbContext context, Type type, ICollection<T> entities, TableInfo tableInfo, Action<decimal>? progress)
     {
         InsertAsync(context, type, entities, tableInfo, progress, isAsync: false, CancellationToken.None).GetAwaiter().GetResult();
     }
 
     /// <inheritdoc/>
-    public async Task InsertAsync<T>(DbContext context, Type type, IList<T> entities, TableInfo tableInfo, Action<decimal>? progress,
+    public async Task InsertAsync<T>(DbContext context, Type type, ICollection<T> entities, TableInfo tableInfo, Action<decimal>? progress,
         CancellationToken cancellationToken)
     {
         await InsertAsync(context, type, entities, tableInfo, progress, isAsync: false, CancellationToken.None).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    protected static async Task InsertAsync<T>(DbContext context, Type type, IList<T> entities, TableInfo tableInfo,
+    protected static async Task InsertAsync<T>(DbContext context, Type type, ICollection<T> entities, TableInfo tableInfo,
         Action<decimal>? progress, bool isAsync, CancellationToken cancellationToken)
     {
         tableInfo.CheckToSetIdentityForPreserveOrder(tableInfo, entities);
@@ -80,21 +80,21 @@ public class MySqlAdapter : ISqlOperationsAdapter
         }
     }
     /// <inheritdoc/>
-    public void Merge<T>(DbContext context, Type type, IList<T> entities, TableInfo tableInfo, OperationType operationType,
+    public void Merge<T>(DbContext context, Type type, ICollection<T> entities, TableInfo tableInfo, OperationType operationType,
         Action<decimal>? progress) where T : class
     {
         MergeAsync(context, type, entities, tableInfo, operationType, progress, isAsync: false, CancellationToken.None).GetAwaiter().GetResult();
     }
 
     /// <inheritdoc/>
-    public async Task MergeAsync<T>(DbContext context, Type type, IList<T> entities, TableInfo tableInfo, OperationType operationType,
+    public async Task MergeAsync<T>(DbContext context, Type type, ICollection<T> entities, TableInfo tableInfo, OperationType operationType,
         Action<decimal>? progress, CancellationToken cancellationToken) where T : class
     {
         await MergeAsync(context, type, entities, tableInfo, operationType, progress, isAsync: true, CancellationToken.None).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    protected async Task MergeAsync<T>(DbContext context, Type type, IList<T> entities, TableInfo tableInfo,
+    protected async Task MergeAsync<T>(DbContext context, Type type, ICollection<T> entities, TableInfo tableInfo,
         OperationType operationType, Action<decimal>? progress, bool isAsync, CancellationToken cancellationToken)
         where T : class
     {
@@ -265,13 +265,13 @@ public class MySqlAdapter : ISqlOperationsAdapter
         
     }
     /// <inheritdoc/>
-    public void Read<T>(DbContext context, Type type, IList<T> entities, TableInfo tableInfo, Action<decimal>? progress) where T : class
+    public void Read<T>(DbContext context, Type type, ICollection<T> entities, TableInfo tableInfo, Action<decimal>? progress) where T : class
     {
         throw new NotImplementedException();
     }
 
     /// <inheritdoc/>
-    public Task ReadAsync<T>(DbContext context, Type type, IList<T> entities, TableInfo tableInfo, Action<decimal>? progress,
+    public Task ReadAsync<T>(DbContext context, Type type, ICollection<T> entities, TableInfo tableInfo, Action<decimal>? progress,
         CancellationToken cancellationToken) where T : class
     {
         throw new NotImplementedException();
@@ -337,7 +337,7 @@ public class MySqlAdapter : ISqlOperationsAdapter
     #endregion
     
     #region DataTable
-    public static DataTable GetDataTable<T>(DbContext context, Type type, IList<T> entities, MySqlBulkCopy mySqlBulkCopy, TableInfo tableInfo)
+    public static DataTable GetDataTable<T>(DbContext context, Type type, ICollection<T> entities, MySqlBulkCopy mySqlBulkCopy, TableInfo tableInfo)
     {
         DataTable dataTable = InnerGetDataTable(context, ref type, entities, tableInfo);
 
@@ -353,7 +353,7 @@ public class MySqlAdapter : ISqlOperationsAdapter
     /// <summary>
     /// Common logic for two versions of GetDataTable
     /// </summary>
-    private static DataTable InnerGetDataTable<T>(DbContext context, ref Type type, IList<T> entities, TableInfo tableInfo)
+    private static DataTable InnerGetDataTable<T>(DbContext context, ref Type type, ICollection<T> entities, TableInfo tableInfo)
     {
         var dataTable = new DataTable();
         var columnsDict = new Dictionary<string, object?>();
@@ -363,7 +363,7 @@ public class MySqlAdapter : ISqlOperationsAdapter
         var isMySql = databaseType == DbServerType.MySQL;
         
         var objectIdentifier = tableInfo.ObjectIdentifier;
-        type = tableInfo.HasAbstractList ? entities[0]!.GetType() : type;
+        type = tableInfo.HasAbstractList ? entities.First()!.GetType() : type;
         var entityType = context.Model.FindEntityType(type) ?? throw new ArgumentException($"Unable to determine entity type from given type - {type.Name}");
         var entityTypeProperties = entityType.GetProperties();
         var entityPropertiesDict = entityTypeProperties.Where(a => tableInfo.PropertyColumnNamesDict.ContainsKey(a.Name) ||

--- a/EFCore.BulkExtensions/SqlAdapters/PostgreSql/PostgreSqlAdapter.cs
+++ b/EFCore.BulkExtensions/SqlAdapters/PostgreSql/PostgreSqlAdapter.cs
@@ -19,19 +19,19 @@ public class PostgreSqlAdapter : ISqlOperationsAdapter
     /// <inheritdoc/>
     #region Methods
     // Insert
-    public void Insert<T>(DbContext context, Type type, IList<T> entities, TableInfo tableInfo, Action<decimal>? progress)
+    public void Insert<T>(DbContext context, Type type, ICollection<T> entities, TableInfo tableInfo, Action<decimal>? progress)
     {
         InsertAsync(context, entities, tableInfo, progress, isAsync: false, CancellationToken.None).GetAwaiter().GetResult();
     }
 
     /// <inheritdoc/>
-    public async Task InsertAsync<T>(DbContext context, Type type, IList<T> entities, TableInfo tableInfo, Action<decimal>? progress, CancellationToken cancellationToken)
+    public async Task InsertAsync<T>(DbContext context, Type type, ICollection<T> entities, TableInfo tableInfo, Action<decimal>? progress, CancellationToken cancellationToken)
     {
         await InsertAsync(context, entities, tableInfo, progress, isAsync: true, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    protected static async Task InsertAsync<T>(DbContext context, IList<T> entities, TableInfo tableInfo, Action<decimal>? progress, bool isAsync, CancellationToken cancellationToken)
+    protected static async Task InsertAsync<T>(DbContext context, ICollection<T> entities, TableInfo tableInfo, Action<decimal>? progress, bool isAsync, CancellationToken cancellationToken)
     {
         NpgsqlConnection? connection = (NpgsqlConnection?)SqlAdaptersMapping.DbServer(context).DbConnection;
         bool closeConnectionInternally = false;
@@ -188,19 +188,19 @@ public class PostgreSqlAdapter : ISqlOperationsAdapter
     }
 
     /// <inheritdoc/>
-    public void Merge<T>(DbContext context, Type type, IList<T> entities, TableInfo tableInfo, OperationType operationType, Action<decimal>? progress) where T : class
+    public void Merge<T>(DbContext context, Type type, ICollection<T> entities, TableInfo tableInfo, OperationType operationType, Action<decimal>? progress) where T : class
     {
         MergeAsync(context, type, entities, tableInfo, operationType, progress, isAsync: false, CancellationToken.None).GetAwaiter().GetResult();
     }
 
     /// <inheritdoc/>
-    public async Task MergeAsync<T>(DbContext context, Type type, IList<T> entities, TableInfo tableInfo, OperationType operationType, Action<decimal>? progress, CancellationToken cancellationToken) where T : class
+    public async Task MergeAsync<T>(DbContext context, Type type, ICollection<T> entities, TableInfo tableInfo, OperationType operationType, Action<decimal>? progress, CancellationToken cancellationToken) where T : class
     {
         await MergeAsync(context, type, entities, tableInfo, operationType, progress, isAsync: true, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    protected async Task MergeAsync<T>(DbContext context, Type type, IList<T> entities, TableInfo tableInfo, OperationType operationType, Action<decimal>? progress, bool isAsync, CancellationToken cancellationToken) where T : class
+    protected async Task MergeAsync<T>(DbContext context, Type type, ICollection<T> entities, TableInfo tableInfo, OperationType operationType, Action<decimal>? progress, bool isAsync, CancellationToken cancellationToken) where T : class
     {
         if (tableInfo.BulkConfig.CustomSourceTableName == null)
         {
@@ -333,15 +333,15 @@ public class PostgreSqlAdapter : ISqlOperationsAdapter
     }
 
     /// <inheritdoc/>
-    public void Read<T>(DbContext context, Type type, IList<T> entities, TableInfo tableInfo, Action<decimal>? progress) where T : class
+    public void Read<T>(DbContext context, Type type, ICollection<T> entities, TableInfo tableInfo, Action<decimal>? progress) where T : class
         => ReadAsync(context, type, entities, tableInfo, progress, isAsync: false, CancellationToken.None).GetAwaiter().GetResult();
 
     /// <inheritdoc/>
-    public async Task ReadAsync<T>(DbContext context, Type type, IList<T> entities, TableInfo tableInfo, Action<decimal>? progress, CancellationToken cancellationToken) where T : class
+    public async Task ReadAsync<T>(DbContext context, Type type, ICollection<T> entities, TableInfo tableInfo, Action<decimal>? progress, CancellationToken cancellationToken) where T : class
         => await ReadAsync(context, type, entities, tableInfo, progress, isAsync: true, cancellationToken).ConfigureAwait(false);
 
     /// <inheritdoc/>
-    protected async Task ReadAsync<T>(DbContext context, Type type, IList<T> entities, TableInfo tableInfo, Action<decimal>? progress, bool isAsync, CancellationToken cancellationToken) where T : class
+    protected async Task ReadAsync<T>(DbContext context, Type type, ICollection<T> entities, TableInfo tableInfo, Action<decimal>? progress, bool isAsync, CancellationToken cancellationToken) where T : class
         => await MergeAsync(context, type, entities, tableInfo, OperationType.Read, progress, isAsync, cancellationToken).ConfigureAwait(false);
 
     /// <inheritdoc/>

--- a/EFCore.BulkExtensions/SqlAdapters/SQLite/SqLiteAdapter.cs
+++ b/EFCore.BulkExtensions/SqlAdapters/SQLite/SqLiteAdapter.cs
@@ -17,20 +17,20 @@ public class SqliteOperationsAdapter : ISqlOperationsAdapter
     #region Methods
 
     /// <inheritdoc/>
-    public void Insert<T>(DbContext context, Type type, IList<T> entities, TableInfo tableInfo, Action<decimal>? progress)
+    public void Insert<T>(DbContext context, Type type, ICollection<T> entities, TableInfo tableInfo, Action<decimal>? progress)
     {
         InsertAsync(context, type, entities, tableInfo, progress, isAsync: false, CancellationToken.None).GetAwaiter().GetResult();
     }
 
 
     /// <inheritdoc/>
-    public async Task InsertAsync<T>(DbContext context, Type type, IList<T> entities, TableInfo tableInfo, Action<decimal>? progress, CancellationToken cancellationToken)
+    public async Task InsertAsync<T>(DbContext context, Type type, ICollection<T> entities, TableInfo tableInfo, Action<decimal>? progress, CancellationToken cancellationToken)
     {
         await InsertAsync(context, type, entities, tableInfo, progress, isAsync: true, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public static async Task InsertAsync<T>(DbContext context, Type type, IList<T> entities, TableInfo tableInfo, Action<decimal>? progress, bool isAsync, CancellationToken cancellationToken)
+    public static async Task InsertAsync<T>(DbContext context, Type type, ICollection<T> entities, TableInfo tableInfo, Action<decimal>? progress, bool isAsync, CancellationToken cancellationToken)
     {
         SqliteConnection? connection = (SqliteConnection?)SqlAdaptersMapping.DbServer(context).DbConnection;
 
@@ -68,7 +68,7 @@ public class SqliteOperationsAdapter : ISqlOperationsAdapter
 
             var command = GetSqliteCommand(context, type, entities, tableInfo, connection, transaction);
 
-            type = tableInfo.HasAbstractList ? entities[0]!.GetType() : type;
+            type = tableInfo.HasAbstractList ? entities.First()!.GetType() : type;
             int rowsCopied = 0;
 
             foreach (var item in entities)
@@ -110,19 +110,19 @@ public class SqliteOperationsAdapter : ISqlOperationsAdapter
 
     // Merge
     /// <inheritdoc/>
-    public void Merge<T>(DbContext context, Type type, IList<T> entities, TableInfo tableInfo, OperationType operationType, Action<decimal>? progress) where T : class
+    public void Merge<T>(DbContext context, Type type, ICollection<T> entities, TableInfo tableInfo, OperationType operationType, Action<decimal>? progress) where T : class
     {
         MergeAsync(context, type, entities, tableInfo, operationType, progress, isAsync: false, CancellationToken.None).GetAwaiter().GetResult();
     }
 
     /// <inheritdoc/>
-    public async Task MergeAsync<T>(DbContext context, Type type, IList<T> entities, TableInfo tableInfo, OperationType operationType, Action<decimal>? progress, CancellationToken cancellationToken) where T : class
+    public async Task MergeAsync<T>(DbContext context, Type type, ICollection<T> entities, TableInfo tableInfo, OperationType operationType, Action<decimal>? progress, CancellationToken cancellationToken) where T : class
     {
         await MergeAsync(context, type, entities, tableInfo, operationType, progress, isAsync: true, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    protected static async Task MergeAsync<T>(DbContext context, Type type, IList<T> entities, TableInfo tableInfo, OperationType operationType, Action<decimal>? progress, bool isAsync, CancellationToken cancellationToken)
+    protected static async Task MergeAsync<T>(DbContext context, Type type, ICollection<T> entities, TableInfo tableInfo, OperationType operationType, Action<decimal>? progress, bool isAsync, CancellationToken cancellationToken)
         where T : class
     {
         SqliteConnection connection = isAsync
@@ -145,7 +145,7 @@ public class SqliteOperationsAdapter : ISqlOperationsAdapter
 
             var command = GetSqliteCommand(context, type, entities, tableInfo, connection, transaction);
 
-            type = tableInfo.HasAbstractList ? entities[0].GetType() : type;
+            type = tableInfo.HasAbstractList ? entities.First().GetType() : type;
             int rowsCopied = 0;
 
             foreach (var item in entities)
@@ -195,19 +195,19 @@ public class SqliteOperationsAdapter : ISqlOperationsAdapter
 
     // Read
     /// <inheritdoc/>
-    public void Read<T>(DbContext context, Type type, IList<T> entities, TableInfo tableInfo, Action<decimal>? progress) where T : class
+    public void Read<T>(DbContext context, Type type, ICollection<T> entities, TableInfo tableInfo, Action<decimal>? progress) where T : class
     {
         ReadAsync(context, type, entities, tableInfo, progress, isAsync: false, CancellationToken.None).GetAwaiter().GetResult();
     }
 
     /// <inheritdoc/>
-    public async Task ReadAsync<T>(DbContext context, Type type, IList<T> entities, TableInfo tableInfo, Action<decimal>? progress, CancellationToken cancellationToken) where T : class
+    public async Task ReadAsync<T>(DbContext context, Type type, ICollection<T> entities, TableInfo tableInfo, Action<decimal>? progress, CancellationToken cancellationToken) where T : class
     {
         await ReadAsync(context, type, entities, tableInfo, progress, isAsync: true, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    protected static async Task ReadAsync<T>(DbContext context, Type type, IList<T> entities, TableInfo tableInfo, Action<decimal>? progress, bool isAsync, CancellationToken cancellationToken) where T : class
+    protected static async Task ReadAsync<T>(DbContext context, Type type, ICollection<T> entities, TableInfo tableInfo, Action<decimal>? progress, bool isAsync, CancellationToken cancellationToken) where T : class
     {
         SqliteConnection connection = isAsync
                                           ? await OpenAndGetSqliteConnectionAsync(context, cancellationToken).ConfigureAwait(false)
@@ -341,7 +341,7 @@ public class SqliteOperationsAdapter : ISqlOperationsAdapter
 
     #region SqliteData
 
-    internal static SqliteCommand GetSqliteCommand<T>(DbContext context, Type? type, IList<T> entities, TableInfo tableInfo, SqliteConnection connection, SqliteTransaction? transaction)
+    internal static SqliteCommand GetSqliteCommand<T>(DbContext context, Type? type, ICollection<T> entities, TableInfo tableInfo, SqliteConnection connection, SqliteTransaction? transaction)
     {
         SqliteCommand command = connection.CreateCommand();
         command.Transaction = transaction;
@@ -371,7 +371,7 @@ public class SqliteOperationsAdapter : ISqlOperationsAdapter
                 break;
         }
 
-        type = tableInfo.HasAbstractList ? entities[0]?.GetType() : type;
+        type = tableInfo.HasAbstractList ? entities.FirstOrDefault()?.GetType() : type;
 
         if (type is null)
         {
@@ -516,7 +516,7 @@ public class SqliteOperationsAdapter : ISqlOperationsAdapter
     }
 
     /// <inheritdoc/>
-    public static void SetIdentityForOutput<T>(IList<T> entities, TableInfo tableInfo, object? lastRowIdScalar)
+    public static void SetIdentityForOutput<T>(ICollection<T> entities, TableInfo tableInfo, object? lastRowIdScalar)
     {
         long counter = (long?)lastRowIdScalar ?? 0;
 
@@ -526,7 +526,9 @@ public class SqliteOperationsAdapter : ISqlOperationsAdapter
         string idTypeName = identityFastProperty.Property.PropertyType.Name;
         object? idValue = null;
 
-        for (int i = entities.Count - 1; i >= 0; i--)
+        // Need indexed access; use IList<T> if available, otherwise copy to list
+        IList<T> list = entities as IList<T> ?? entities.ToList();
+        for (int i = list.Count - 1; i >= 0; i--)
         {
             idValue = idTypeName switch
             {
@@ -541,9 +543,9 @@ public class SqliteOperationsAdapter : ISqlOperationsAdapter
                 _ => counter,
             };
 
-            if (entities[i] is not null)
+            if (list[i] is not null)
             {
-                identityFastProperty.Set(entities[i]!, idValue);
+                identityFastProperty.Set(list[i]!, idValue);
             }
 
             counter--;

--- a/EFCore.BulkExtensions/SqlAdapters/SqlServer/SqlServerAdapter.cs
+++ b/EFCore.BulkExtensions/SqlAdapters/SqlServer/SqlServerAdapter.cs
@@ -38,13 +38,13 @@ public sealed class SqlOperationsServerAdapter: ISqlOperationsAdapter
     #region Methods
 
     /// <inheritdoc/>
-    public void Insert<T>(DbContext context, Type type, IList<T> entities, TableInfo tableInfo, Action<decimal>? progress)
+    public void Insert<T>(DbContext context, Type type, ICollection<T> entities, TableInfo tableInfo, Action<decimal>? progress)
     {
         InsertAsync(context, type, entities, tableInfo, progress, isAsync: false, CancellationToken.None).GetAwaiter().GetResult();
     }
 
     /// <inheritdoc/>
-    public async Task InsertAsync<T>(DbContext context, Type type, IList<T> entities, TableInfo tableInfo, Action<decimal>? progress, CancellationToken cancellationToken)
+    public async Task InsertAsync<T>(DbContext context, Type type, ICollection<T> entities, TableInfo tableInfo, Action<decimal>? progress, CancellationToken cancellationToken)
     {
         await InsertAsync(context, type, entities, tableInfo, progress, isAsync: true, cancellationToken).ConfigureAwait(false);
     }
@@ -125,7 +125,7 @@ public sealed class SqlOperationsServerAdapter: ISqlOperationsAdapter
     }
 
     
-    private static async Task InsertAsync<T>(DbContext context, Type type, IList<T> entities, TableInfo tableInfo, Action<decimal>? progress, bool isAsync, CancellationToken cancellationToken)
+    private static async Task InsertAsync<T>(DbContext context, Type type, ICollection<T> entities, TableInfo tableInfo, Action<decimal>? progress, bool isAsync, CancellationToken cancellationToken)
     {
         tableInfo.CheckToSetIdentityForPreserveOrder(tableInfo, entities);
         if (isAsync)
@@ -203,13 +203,13 @@ public sealed class SqlOperationsServerAdapter: ISqlOperationsAdapter
     }
 
     /// <inheritdoc/>
-    public void Merge<T>(DbContext context, Type type, IList<T> entities, TableInfo tableInfo, OperationType operationType, Action<decimal>? progress) where T : class
+    public void Merge<T>(DbContext context, Type type, ICollection<T> entities, TableInfo tableInfo, OperationType operationType, Action<decimal>? progress) where T : class
     {
         MergeAsync(context, type, entities, tableInfo, operationType, progress, isAsync: false, CancellationToken.None).GetAwaiter().GetResult();
     }
 
     /// <inheritdoc/>
-    public async Task MergeAsync<T>(DbContext context, Type type, IList<T> entities, TableInfo tableInfo, OperationType operationType, Action<decimal>? progress, CancellationToken cancellationToken) where T : class
+    public async Task MergeAsync<T>(DbContext context, Type type, ICollection<T> entities, TableInfo tableInfo, OperationType operationType, Action<decimal>? progress, CancellationToken cancellationToken) where T : class
     {
         await MergeAsync(context, type, entities, tableInfo, operationType, progress, isAsync: true, cancellationToken).ConfigureAwait(false);
     }
@@ -231,7 +231,7 @@ public sealed class SqlOperationsServerAdapter: ISqlOperationsAdapter
         return q;
     }
     
-    private async Task MergeAsync<T>(DbContext context, Type type, IList<T> entities, TableInfo tableInfo, OperationType operationType, Action<decimal>? progress, bool isAsync, CancellationToken cancellationToken) where T : class
+    private async Task MergeAsync<T>(DbContext context, Type type, ICollection<T> entities, TableInfo tableInfo, OperationType operationType, Action<decimal>? progress, bool isAsync, CancellationToken cancellationToken) where T : class
     {
         var entityPropertyWithDefaultValue = entities.GetPropertiesWithDefaultValue(type, tableInfo);
 
@@ -419,18 +419,18 @@ public sealed class SqlOperationsServerAdapter: ISqlOperationsAdapter
     }
 
     /// <inheritdoc/>
-    public void Read<T>(DbContext context, Type type, IList<T> entities, TableInfo tableInfo, Action<decimal>? progress) where T : class
+    public void Read<T>(DbContext context, Type type, ICollection<T> entities, TableInfo tableInfo, Action<decimal>? progress) where T : class
     {
         ReadAsync(context, type, entities, tableInfo, progress, isAsync: false, CancellationToken.None).GetAwaiter().GetResult();
     }
 
     /// <inheritdoc/>
-    public async Task ReadAsync<T>(DbContext context, Type type, IList<T> entities, TableInfo tableInfo, Action<decimal>? progress, CancellationToken cancellationToken) where T : class
+    public async Task ReadAsync<T>(DbContext context, Type type, ICollection<T> entities, TableInfo tableInfo, Action<decimal>? progress, CancellationToken cancellationToken) where T : class
     {
         await ReadAsync(context, type, entities, tableInfo, progress, isAsync: true, cancellationToken).ConfigureAwait(false);
     }
 
-    private async Task ReadAsync<T>(DbContext context, Type type, IList<T> entities, TableInfo tableInfo, Action<decimal>? progress, bool isAsync, CancellationToken cancellationToken) where T : class
+    private async Task ReadAsync<T>(DbContext context, Type type, ICollection<T> entities, TableInfo tableInfo, Action<decimal>? progress, bool isAsync, CancellationToken cancellationToken) where T : class
     {
         Dictionary<string, string> previousPropertyColumnNamesDict = tableInfo.ConfigureBulkReadTableInfo();
 
@@ -529,7 +529,7 @@ public sealed class SqlOperationsServerAdapter: ISqlOperationsAdapter
         return sqlBulkCopy;
     }
   
-    private static void SetSqlBulkCopyConfig<T>(SqlBulkCopy sqlBulkCopy, TableInfo tableInfo, IList<T> entities, bool setColumnMapping, Action<decimal>? progress)
+    private static void SetSqlBulkCopyConfig<T>(SqlBulkCopy sqlBulkCopy, TableInfo tableInfo, ICollection<T> entities, bool setColumnMapping, Action<decimal>? progress)
     {
         sqlBulkCopy.DestinationTableName = tableInfo.InsertToTempTable ? tableInfo.FullTempTableName : tableInfo.FullTableName;
         sqlBulkCopy.BatchSize = tableInfo.BulkConfig.BatchSize;
@@ -556,7 +556,7 @@ public sealed class SqlOperationsServerAdapter: ISqlOperationsAdapter
     /// <summary>
     /// Supports <see cref="SqlBulkCopy"/>
     /// </summary>
-    internal static DataTable GetDataTable<T>(DbContext context, Type type, IList<T> entities, SqlBulkCopy sqlBulkCopy, TableInfo tableInfo)
+    internal static DataTable GetDataTable<T>(DbContext context, Type type, ICollection<T> entities, SqlBulkCopy sqlBulkCopy, TableInfo tableInfo)
     {
         DataTable dataTable = InnerGetDataTable(context, ref type, entities, tableInfo);
 
@@ -571,7 +571,7 @@ public sealed class SqlOperationsServerAdapter: ISqlOperationsAdapter
     /// <summary>
     /// Common logic for two versions of GetDataTable
     /// </summary>
-    private static DataTable InnerGetDataTable<T>(DbContext context, ref Type type, IList<T> entities, TableInfo tableInfo)
+    private static DataTable InnerGetDataTable<T>(DbContext context, ref Type type, ICollection<T> entities, TableInfo tableInfo)
     {
         var dataTable = new DataTable();
         var columnsDict = new Dictionary<string, object?>();
@@ -582,7 +582,7 @@ public sealed class SqlOperationsServerAdapter: ISqlOperationsAdapter
         var sqlServerBytesWriter = new SqlServerBytesWriter();
 
         var objectIdentifier = tableInfo.ObjectIdentifier;
-        type = tableInfo.HasAbstractList ? entities[0]!.GetType() : type;
+        type = tableInfo.HasAbstractList ? entities.First()!.GetType() : type;
         var entityType = context.Model.FindEntityType(type) ?? throw new ArgumentException($"Unable to determine entity type from given type - {type.Name}");
         var entityTypeProperties = entityType.GetProperties().ToList();
         var entityPropertiesDict = entityTypeProperties.Where(a => tableInfo.PropertyColumnNamesDict.ContainsKey(a.Name) ||

--- a/EFCore.BulkExtensions/SqlBulkOperation.cs
+++ b/EFCore.BulkExtensions/SqlBulkOperation.cs
@@ -50,31 +50,31 @@ internal static class SqlBulkOperation
 {
     internal static string ColumnMappingExceptionMessage => "The given ColumnMapping does not match up with any column in the source or destination";
 
-    public static void Insert<T>(DbContext context, Type type, IList<T> entities, TableInfo tableInfo, Action<decimal>? progress)
+    public static void Insert<T>(DbContext context, Type type, ICollection<T> entities, TableInfo tableInfo, Action<decimal>? progress)
     {
         var adapter = SqlAdaptersMapping.CreateBulkOperationsAdapter(context);
         adapter.Insert(context, type, entities, tableInfo, progress);
     }
 
-    public static async Task InsertAsync<T>(DbContext context, Type type, IList<T> entities, TableInfo tableInfo, Action<decimal>? progress, CancellationToken cancellationToken)
+    public static async Task InsertAsync<T>(DbContext context, Type type, ICollection<T> entities, TableInfo tableInfo, Action<decimal>? progress, CancellationToken cancellationToken)
     {
         var adapter = SqlAdaptersMapping.CreateBulkOperationsAdapter(context);
         await adapter.InsertAsync(context, type, entities, tableInfo, progress, cancellationToken).ConfigureAwait(false);
     }
 
-    public static void Merge<T>(DbContext context, Type type, IList<T> entities, TableInfo tableInfo, OperationType operationType, Action<decimal>? progress) where T : class
+    public static void Merge<T>(DbContext context, Type type, ICollection<T> entities, TableInfo tableInfo, OperationType operationType, Action<decimal>? progress) where T : class
     {
         var adapter = SqlAdaptersMapping.CreateBulkOperationsAdapter(context);
         adapter.Merge(context, type, entities, tableInfo, operationType, progress);
     }
 
-    public static async Task MergeAsync<T>(DbContext context, Type type, IList<T> entities, TableInfo tableInfo, OperationType operationType, Action<decimal>? progress, CancellationToken cancellationToken = default) where T : class
+    public static async Task MergeAsync<T>(DbContext context, Type type, ICollection<T> entities, TableInfo tableInfo, OperationType operationType, Action<decimal>? progress, CancellationToken cancellationToken = default) where T : class
     {
         var adapter = SqlAdaptersMapping.CreateBulkOperationsAdapter(context);
         await adapter.MergeAsync(context, type, entities, tableInfo, operationType, progress, cancellationToken).ConfigureAwait(false);
     }
 
-    public static void Read<T>(DbContext context, Type type, IList<T> entities, TableInfo tableInfo, Action<decimal>? progress) where T : class
+    public static void Read<T>(DbContext context, Type type, ICollection<T> entities, TableInfo tableInfo, Action<decimal>? progress) where T : class
     {
         if (tableInfo.BulkConfig.UseTempDB) // dropTempTableIfExists
         {
@@ -84,7 +84,7 @@ internal static class SqlBulkOperation
         adapter.Read(context, type, entities, tableInfo, progress);
     }
 
-    public static async Task ReadAsync<T>(DbContext context, Type type, IList<T> entities, TableInfo tableInfo, Action<decimal>? progress, CancellationToken cancellationToken) where T : class
+    public static async Task ReadAsync<T>(DbContext context, Type type, ICollection<T> entities, TableInfo tableInfo, Action<decimal>? progress, CancellationToken cancellationToken) where T : class
     {
         if (tableInfo.BulkConfig.UseTempDB) // dropTempTableIfExists
         {

--- a/EFCore.BulkExtensions/TableInfo.cs
+++ b/EFCore.BulkExtensions/TableInfo.cs
@@ -96,7 +96,7 @@ public class TableInfo
     /// <summary>
     /// Creates an instance of TableInfo
     /// </summary>
-    public static TableInfo CreateInstance<T>(DbContext context, Type? type, IList<T> entities, OperationType operationType, BulkConfig? bulkConfig)
+    public static TableInfo CreateInstance<T>(DbContext context, Type? type, ICollection<T> entities, OperationType operationType, BulkConfig? bulkConfig)
     {
         var tableInfo = new TableInfo
         {
@@ -124,14 +124,14 @@ public class TableInfo
     /// <summary>
     /// Configures the table info based on entity data 
     /// </summary>
-    public void LoadData<T>(DbContext context, Type? type, IList<T> entities, bool loadOnlyPKColumn)
+    public void LoadData<T>(DbContext context, Type? type, ICollection<T> entities, bool loadOnlyPKColumn)
 
     {
         LoadOnlyPKColumn = loadOnlyPKColumn;
         var entityType = type is null ? null : context.Model.FindEntityType(type);
         if (entityType == null)
         {
-            type = entities[0]?.GetType() ?? throw new ArgumentNullException(nameof(type));
+            type = entities.FirstOrDefault()?.GetType() ?? throw new ArgumentNullException(nameof(type));
             entityType = context.Model.FindEntityType(type);
             HasAbstractList = true;
         }
@@ -729,7 +729,7 @@ public class TableInfo
         return previousPropertyColumnNamesDict;
     }
 
-    internal void UpdateReadEntities<T>(IList<T> entities, IList<T> existingEntities, DbContext context)
+    internal void UpdateReadEntities<T>(ICollection<T> entities, ICollection<T> existingEntities, DbContext context)
     {
         List<string> propertyNames = PropertyColumnNamesDict.Keys.ToList();
         if (HasOwnedTypes)
@@ -757,14 +757,14 @@ public class TableInfo
 
         for (int i = 0; i < NumberOfEntities; i++)
         {
-            T entity = entities[i];
+            T entity = entities.ElementAt(i);
             string uniqueProperyValues = GetUniquePropertyValues(entity!, selectByPropertyNames, FastPropertyDict);
 
             existingEntitiesDict.TryGetValue(uniqueProperyValues, out T? existingEntity);
             bool isPostgreSQL = context.Database.ProviderName?.EndsWith(DbServerType.PostgreSQL.ToString()) ?? false;
             if (existingEntity == null && isPostgreSQL && i < existingEntities.Count)
             {
-                existingEntity = existingEntities[i]; // TODO check if BinaryImport with COPY on Postgres preserves order
+                existingEntity = existingEntities.ElementAt(i); // TODO check if BinaryImport with COPY on Postgres preserves order
             }
             if (existingEntity != null)
             {
@@ -785,7 +785,7 @@ public class TableInfo
         }
     }
 
-    internal void ReplaceReadEntities<T>(IList<T> entities, IList<T> existingEntities)
+    internal void ReplaceReadEntities<T>(ICollection<T> entities, ICollection<T> existingEntities)
     {
         entities.Clear();
 
@@ -799,7 +799,7 @@ public class TableInfo
     /// <summary>
     /// Sets the identity preserve order
     /// </summary>
-    public void CheckToSetIdentityForPreserveOrder<T>(TableInfo tableInfo, IList<T> entities, bool reset = false)
+    public void CheckToSetIdentityForPreserveOrder<T>(TableInfo tableInfo, ICollection<T> entities, bool reset = false)
     {
         string identityPropertyName = PropertyColumnNamesDict.SingleOrDefault(a => a.Value == IdentityColumnName).Key;
 
@@ -813,7 +813,7 @@ public class TableInfo
         {
             if (operationType == OperationType.Insert) // Insert should either have all zeros for automatic order, or they can be manually set
             {
-                var propertyValue = FastPropertyDict[identityPropertyName].Get(entities[0]!);
+                var propertyValue = FastPropertyDict[identityPropertyName].Get(entities.ElementAt(0)!);
                 var identityValue = Convert.ToInt64(IdentityColumnConverter != null ? IdentityColumnConverter.ConvertToProvider(propertyValue) : propertyValue);
 
                 if (identityValue != 0) // (to check it fast, condition for all 0s is only done on first one)
@@ -902,7 +902,7 @@ public class TableInfo
     /// <summary>
     /// Updates the entities' identity field
     /// </summary>
-    internal void UpdateEntitiesIdentity<T>(TableInfo tableInfo, IList<T> entities, IList<object> entitiesWithOutputIdentity)
+    internal void UpdateEntitiesIdentity<T>(TableInfo tableInfo, ICollection<T> entities, ICollection<object> entitiesWithOutputIdentity)
     {
         var identifierPropertyName = IdentityColumnName != null ? OutputPropertyColumnNamesDict.SingleOrDefault(a => a.Value == IdentityColumnName).Key // it Identity autoincrement 
                                                                 : PrimaryKeysPropertyColumnNameDict.FirstOrDefault().Key;                               // or PK with default sql value
@@ -939,7 +939,9 @@ public class TableInfo
 
             if (tableInfo.EntitiesSortedReference != null)
             {
-                entities = tableInfo.EntitiesSortedReference.Cast<T>().ToList();
+                // When PreserveInsertOrder sorting was applied we replace iteration source with sorted reference
+                var sorted = tableInfo.EntitiesSortedReference.Cast<T>().ToList();
+                entities = sorted;
             }
             
             
@@ -1011,17 +1013,23 @@ public class TableInfo
             entities.Clear();
             if (typeof(T) == entitiesWithOutputIdentity.FirstOrDefault()?.GetType())
             {
-                ((List<T>)entities).AddRange(entitiesWithOutputIdentity.Cast<T>().ToList());
+                foreach (var e in entitiesWithOutputIdentity.Cast<T>())
+                {
+                    entities.Add(e);
+                }
             }
             else
             {
-                var entitiesObjects = entities.Cast<object>().ToList();
-                entitiesObjects.AddRange(entitiesWithOutputIdentity);
+                foreach (var obj in entitiesWithOutputIdentity)
+                {
+                    if (obj is T t)
+                        entities.Add(t);
+                }
             }
         }
     }
 
-    internal void UpdateEntitiesIdentityByMap<T>(TableInfo tableInfo, IList<T> entities, List<IndexToGeneratedId> indexToGeneratedIds)
+    internal void UpdateEntitiesIdentityByMap<T>(TableInfo tableInfo, ICollection<T> entities, System.Collections.Generic.List<IndexToGeneratedId> indexToGeneratedIds)
     {
         var identifierPropertyName = IdentityColumnName != null ? OutputPropertyColumnNamesDict.SingleOrDefault(a => a.Value == IdentityColumnName).Key // it Identity autoincrement 
                                          : PrimaryKeysPropertyColumnNameDict.FirstOrDefault().Key;                                                      // or PK with default sql value
@@ -1037,7 +1045,7 @@ public class TableInfo
             // In case of setting output identity, we cannot decide which id we should use (as there might be multiple rows in output table, which 'belong' to only one row in source table).
                 
             var customPk = tableInfo.PrimaryKeysPropertyColumnNameDict.Keys;
-            var nonUniqueEntities = mappingDictionary.Where(x => x.Value.Count > 1).Select(x => x.Key).Select(x => entities[x]).ToList();
+            var nonUniqueEntities = mappingDictionary.Where(x => x.Value.Count > 1).Select(x => x.Key).Select(index => entities.ElementAt(index)).ToList();
 
             var nonUniqueKeys = nonUniqueEntities.Select(x => new PrimaryKeysPropertyColumnNameValues(customPk.Select(c => FastPropertyDict[c].Get(x!)))).ToList();
                 
@@ -1049,7 +1057,7 @@ public class TableInfo
 
         for (int index = 0; index < NumberOfEntities; index++)
         {
-            T entityToBeFilled = entities[index]!;
+            T entityToBeFilled = entities.ElementAt(index)!;
 
             if (!mappingDictionary.TryGetValue(index, out var  mapping))
             {
@@ -1084,7 +1092,7 @@ public class TableInfo
     // https://github.com/aspnet/EntityFrameworkCore/issues/12905
     #region CompiledQuery
 
-    public async Task LoadOutputDataAsync<T>(DbContext context, Type type, IList<T> entities, TableInfo tableInfo, bool isAsync, CancellationToken cancellationToken) where T : class
+    public async Task LoadOutputDataAsync<T>(DbContext context, Type type, ICollection<T> entities, TableInfo tableInfo, bool isAsync, CancellationToken cancellationToken) where T : class
     {
         bool hasIdentity = OutputPropertyColumnNamesDict.Any(a => a.Value == IdentityColumnName) ||
                            (tableInfo.HasSinglePrimaryKey && tableInfo.DefaultValueProperties.Contains(tableInfo.PrimaryKeysPropertyColumnNameDict.FirstOrDefault().Key));
@@ -1301,7 +1309,7 @@ public class TableInfo
         }
     }
 
-    public async Task UpdateOutputIdentityAsync<T>(DbContext context, IList<T> entities) where T : class
+    public async Task UpdateOutputIdentityAsync<T>(DbContext context, ICollection<T> entities) where T : class
     {
         if (HasSinglePrimaryKey)
         {


### PR DESCRIPTION
Replaced IList<T> parameters with ICollection<T> for BulkInsert-related APIs.

This allows BulkInsert callers to pass more general collection types while still supporting existing IList<T> and List<T> usages, since IList<T> implements ICollection<T>.

The internal execution path converts the incoming ICollection<T> to IList<T> only when downstream operations require list/index-based access. If the provided collection already implements IList<T>, it is reused directly without copying. Non-list ICollection<T> implementations are materialized into a List<T> before continuing through the existing bulk operation pipeline.